### PR TITLE
feat: Add React Router Link to Header Component for non-reload navigation 

### DIFF
--- a/06_building_stuff/src/components/Header.jsx
+++ b/06_building_stuff/src/components/Header.jsx
@@ -1,5 +1,6 @@
 import { LOGO_URL } from "../utils/constants";
 import { useState } from "react";
+import { Link } from "react-router-dom";
 
 export default function Header() {
   const [loginButton, setLoginButton] = useState("Login");
@@ -8,15 +9,15 @@ export default function Header() {
     <header className="header">
       <div className="navContainer flex-sa">
         <div className="logocontainer">
-          <a href="/">
+          <Link to="/">
             <img className="logo" src={LOGO_URL} alt="Logo" />
-          </a>
+          </Link>
         </div>
         <div className="nav-items">
           <ul className="flex-center" style={{ gap: "2rem" }}>
-            <a href="/contactus">
-              <li style={{ "max-width": "7rem" }}>Contact Us</li>
-            </a>
+            <Link to="/contactus">
+              <li style={{ maxWidth: "7rem" }}>Contact Us</li>
+            </Link>
             <li>Cart</li>
             <button
               onClick={() => {

--- a/06_building_stuff/src/components/Main.jsx
+++ b/06_building_stuff/src/components/Main.jsx
@@ -18,7 +18,7 @@ async function fetchDataSetData(dataAPI) {
       const response = await fetch(dataAPI);
       const dataJSON = await response.json();
       const restData =
-        dataJSON?.data?.cards[4]?.card?.card?.gridElements?.infoWithStyle
+        dataJSON?.data?.cards[1]?.card?.card?.gridElements?.infoWithStyle
           ?.restaurants;
 
       setRestaurantData(sliceData(restData));


### PR DESCRIPTION
Integrate the `Link` component from `react-router-dom` into the Header component. 

This allows for client-side navigation without full page reloads, enhancing the user experience by making navigation faster and smoother.